### PR TITLE
fix: Replace global redirect flag with React state in LoginCallback

### DIFF
--- a/src/react/LoginCallBack.js
+++ b/src/react/LoginCallBack.js
@@ -7,15 +7,14 @@
 * 
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { useOCAuth } from './OCContext';
-
-let handledRedirect = false;
 
 const LoginCallBack = ( { successCallback, errorCallback, customErrorComponent, customLoadingComponent } ) =>
 {
     const { isInitialized, ocAuth, authState, setAuthError } = useOCAuth();
+    const [handledRedirect, setHandledRedirect] = useState(false);
 
     useEffect( () =>
     {
@@ -26,10 +25,12 @@ const LoginCallBack = ( { successCallback, errorCallback, customErrorComponent, 
                 try
                 {
                     await ocAuth.handleLoginRedirect();
+                    setHandledRedirect(true);
                     successCallback();
                 } catch (e)
                 {
                     setAuthError(e);
+                    setHandledRedirect(true);
                     if (errorCallback)
                     {
                         errorCallback();


### PR DESCRIPTION
This commit improves the LoginCallback component by:
- Replacing global handledRedirect variable with React useState hook
- Making redirect state local to component instance
- Adding proper state management for redirect handling
- Removing global variable declaration

This change prevents potential issues with component reuse and follows React best practices for state management.